### PR TITLE
⚡ Bolt: Add fast path for single batch build side in HashJoin

### DIFF
--- a/datafusion/physical-plan/src/joins/hash_join/exec.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/exec.rs
@@ -1676,7 +1676,12 @@ async fn collect_left_input(
             }
 
             // Merge all batches into a single batch, so we can directly index into the arrays
-            let batch = concat_batches(&schema, batches_iter.clone())?;
+            let batch = if batches.len() == 1 {
+                // Optimization: If there is only one batch, no need to concatenate.
+                batches[0].clone()
+            } else {
+                concat_batches(&schema, batches_iter.clone())?
+            };
 
             let left_values = evaluate_expressions_to_arrays(&on_left, &batch)?;
 


### PR DESCRIPTION
This PR introduces a performance optimization to the `HashJoinExec` operator. It adds a fast path to avoid an unnecessary `concat_batches` call when the build side of the join consists of a single `RecordBatch`, thereby reducing memory allocation and CPU overhead in this common scenario.

---
*PR created automatically by Jules for task [17536242971790051292](https://jules.google.com/task/17536242971790051292) started by @Dandandan*