### PR TITLE
⚡ Bolt: Use AtomicBitSet for join visited indices

### DIFF
--- a/datafusion/physical-plan/src/joins/atomic_bit_set.rs
+++ b/datafusion/physical-plan/src/joins/atomic_bit_set.rs
@@ -1,0 +1,92 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! AtomicBitSet for thread-safe bitwise operations.
+
+use std::mem::size_of;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use arrow::buffer::{BooleanBuffer, Buffer};
+
+/// A thread-safe bitset that allows multiple threads to set bits concurrently
+/// without lock contention.
+#[derive(Debug)]
+pub struct AtomicBitSet {
+    data: Arc<[AtomicUsize]>,
+    len: usize,
+}
+
+impl AtomicBitSet {
+    /// Create a new AtomicBitSet with the given number of bits, all initialized to false.
+    pub fn new(len: usize) -> Self {
+        let word_size = size_of::<usize>() * 8;
+        let num_words = len.div_ceil(word_size);
+        let mut data = Vec::with_capacity(num_words);
+        for _ in 0..num_words {
+            data.push(AtomicUsize::new(0));
+        }
+        Self {
+            data: data.into(),
+            len,
+        }
+    }
+
+    /// Set the bit at the given index to true.
+    pub fn set_bit(&self, idx: usize, value: bool) {
+        if !value {
+            // Currently we only support setting to true atomically.
+            // If we need to support setting to false, we can use fetch_and.
+            return;
+        }
+        let word_size = size_of::<usize>() * 8;
+        let word_idx = idx / word_size;
+        let bit_idx = idx % word_size;
+        let mask = 1 << bit_idx;
+        self.data[word_idx].fetch_or(mask, Ordering::Relaxed);
+    }
+
+    /// Get the bit at the given index.
+    pub fn get_bit(&self, idx: usize) -> bool {
+        let word_size = size_of::<usize>() * 8;
+        let word_idx = idx / word_size;
+        let bit_idx = idx % word_size;
+        let mask = 1 << bit_idx;
+        (self.data[word_idx].load(Ordering::Relaxed) & mask) != 0
+    }
+
+    /// Returns the number of bits in the bitset.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns true if the bitset is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Convert the AtomicBitSet to a BooleanBuffer.
+    pub fn to_boolean_buffer(&self) -> BooleanBuffer {
+        let mut bytes = Vec::with_capacity(self.data.len() * size_of::<usize>());
+        for word in self.data.as_ref() {
+            let val = word.load(Ordering::Relaxed);
+            bytes.extend_from_slice(&val.to_le_bytes());
+        }
+        bytes.truncate(self.len.div_ceil(8));
+        BooleanBuffer::new(Buffer::from(bytes), 0, self.len)
+    }
+}

--- a/datafusion/physical-plan/src/joins/hash_join/exec.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/exec.rs
@@ -36,6 +36,7 @@ use crate::joins::hash_join::shared_bounds::{
 use crate::joins::hash_join::stream::{
     BuildSide, BuildSideInitialState, HashJoinStream, HashJoinStreamState,
 };
+use crate::joins::atomic_bit_set::AtomicBitSet;
 use crate::joins::join_hash_map::{JoinHashMapU32, JoinHashMapU64};
 use crate::joins::utils::{
     OnceAsync, OnceFut, asymmetric_join_output_partitioning, reorder_output_after_swap,
@@ -61,7 +62,7 @@ use crate::{
     metrics::{ExecutionPlanMetricsSet, MetricsSet},
 };
 
-use arrow::array::{ArrayRef, BooleanBufferBuilder};
+use arrow::array::ArrayRef;
 use arrow::compute::concat_batches;
 use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatch;
@@ -87,7 +88,6 @@ use ahash::RandomState;
 use datafusion_physical_expr_common::physical_expr::fmt_sql;
 use datafusion_physical_expr_common::utils::evaluate_expressions_to_arrays;
 use futures::TryStreamExt;
-use parking_lot::Mutex;
 
 use super::partitioned_hash_eval::SeededRandomState;
 
@@ -1689,11 +1689,9 @@ async fn collect_left_input(
         reservation.try_grow(bitmap_size)?;
         metrics.build_mem_used.add(bitmap_size);
 
-        let mut bitmap_buffer = BooleanBufferBuilder::new(batch.num_rows());
-        bitmap_buffer.append_n(num_rows, false);
-        bitmap_buffer
+        AtomicBitSet::new(batch.num_rows())
     } else {
-        BooleanBufferBuilder::new(0)
+        AtomicBitSet::new(0)
     };
 
     let map = Arc::new(join_hash_map);
@@ -1732,7 +1730,7 @@ async fn collect_left_input(
         map,
         batch,
         values: left_values,
-        visited_indices_bitmap: Mutex::new(visited_indices_bitmap),
+        visited_indices_bitmap: Arc::new(visited_indices_bitmap),
         probe_threads_counter: AtomicUsize::new(probe_threads_count),
         _reservation: reservation,
         bounds,

--- a/datafusion/physical-plan/src/joins/hash_join/stream.rs
+++ b/datafusion/physical-plan/src/joins/hash_join/stream.rs
@@ -719,7 +719,7 @@ impl HashJoinStream {
 
         // mark joined left-side indices as visited, if required by join type
         if need_produce_result_in_final(self.join_type) {
-            let mut bitmap = build_side.left_data.visited_indices_bitmap().lock();
+            let bitmap = build_side.left_data.visited_indices_bitmap();
             left_indices.iter().flatten().for_each(|x| {
                 bitmap.set_bit(x as usize, true);
             });

--- a/datafusion/physical-plan/src/joins/mod.rs
+++ b/datafusion/physical-plan/src/joins/mod.rs
@@ -17,12 +17,12 @@
 
 //! DataFusion Join implementations
 
-use arrow::array::BooleanBufferBuilder;
+use std::sync::Arc;
+
 pub use cross_join::CrossJoinExec;
 use datafusion_physical_expr::PhysicalExprRef;
 pub use hash_join::{HashExpr, HashJoinExec, HashTableLookupExpr, SeededRandomState};
 pub use nested_loop_join::NestedLoopJoinExec;
-use parking_lot::Mutex;
 // Note: SortMergeJoin is not used in plans yet
 pub use piecewise_merge_join::PiecewiseMergeJoinExec;
 pub use sort_merge_join::SortMergeJoinExec;
@@ -43,9 +43,11 @@ mod join_filter;
 ///
 /// Note: This module is public for internal testing purposes only
 /// and is not guaranteed to be stable across versions.
+pub mod atomic_bit_set;
 pub mod join_hash_map;
 
 use array_map::ArrayMap;
+use atomic_bit_set::AtomicBitSet;
 use utils::JoinHashMapType;
 
 pub enum Map {
@@ -101,4 +103,4 @@ pub enum StreamJoinPartitionMode {
 }
 
 /// Shared bitmap for visited left-side indices
-type SharedBitmapBuilder = Mutex<BooleanBufferBuilder>;
+pub type SharedBitmapBuilder = Arc<AtomicBitSet>;

--- a/datafusion/physical-plan/src/joins/nested_loop_join.rs
+++ b/datafusion/physical-plan/src/joins/nested_loop_join.rs
@@ -30,6 +30,7 @@ use super::utils::{
 };
 use crate::common::can_project;
 use crate::execution_plan::{EmissionType, boundedness_from_children};
+use crate::joins::atomic_bit_set::AtomicBitSet;
 use crate::joins::SharedBitmapBuilder;
 use crate::joins::utils::{
     BuildProbeJoinMetrics, ColumnIndex, JoinFilter, OnceAsync, OnceFut,
@@ -73,7 +74,6 @@ use datafusion_physical_expr::equivalence::{
 
 use futures::{Stream, StreamExt, TryStreamExt};
 use log::debug;
-use parking_lot::Mutex;
 
 #[expect(rustdoc::private_intra_doc_links)]
 /// NestedLoopJoinExec is a build-probe join operator designed for joins that
@@ -709,16 +709,14 @@ async fn collect_left_input(
         reservation.try_grow(buffer_size)?;
         metrics.build_mem_used.add(buffer_size);
 
-        let mut buffer = BooleanBufferBuilder::new(n_rows);
-        buffer.append_n(n_rows, false);
-        buffer
+        AtomicBitSet::new(n_rows)
     } else {
-        BooleanBufferBuilder::new(0)
+        AtomicBitSet::new(0)
     };
 
     Ok(JoinLeftData::new(
         merged_batch,
-        Mutex::new(visited_left_side),
+        Arc::new(visited_left_side),
         AtomicUsize::new(probe_threads_count),
         reservation,
     ))
@@ -1426,8 +1424,8 @@ impl NestedLoopJoinStream {
         // -----------------------------------------------------------
 
         // None means we don't have to update left bitmap for this join type
-        let mut left_bitmap = if need_produce_result_in_final(self.join_type) {
-            Some(left_data.bitmap().lock())
+        let left_bitmap = if need_produce_result_in_final(self.join_type) {
+            Some(left_data.bitmap())
         } else {
             None
         };
@@ -1453,17 +1451,17 @@ impl NestedLoopJoinStream {
             let l_index = l_start_index + i / right_rows;
             let r_index = i % right_rows;
 
-            if let Some(bitmap) = left_bitmap.as_mut()
+            if let Some(l_bitmap) = left_bitmap
                 && is_matched
             {
                 // Map local index back to absolute left index within the batch
-                bitmap.set_bit(l_index, true);
+                l_bitmap.set_bit(l_index, true);
             }
 
-            if let Some(bitmap) = local_right_bitmap.as_mut()
+            if let Some(r_bitmap) = local_right_bitmap.as_mut()
                 && is_matched
             {
-                bitmap.set_bit(r_index, true);
+                r_bitmap.set_bit(r_index, true);
             }
         }
 
@@ -1663,16 +1661,10 @@ impl NestedLoopJoinStream {
         let left_batch = left_data.batch();
         let left_batch_sliced = left_batch.slice(start_idx, end_idx - start_idx);
 
-        // Can this be more efficient?
+        let bitmap = left_data.bitmap();
         let mut bitmap_sliced = BooleanBufferBuilder::new(end_idx - start_idx);
-        bitmap_sliced.append_n(end_idx - start_idx, false);
-        let bitmap = left_data.bitmap().lock();
         for i in start_idx..end_idx {
-            assert!(
-                i - start_idx < bitmap_sliced.capacity(),
-                "DBG: {start_idx}, {end_idx}"
-            );
-            bitmap_sliced.set_bit(i - start_idx, bitmap.get_bit(i));
+            bitmap_sliced.append(bitmap.get_bit(i));
         }
         let bitmap_sliced = BooleanArray::new(bitmap_sliced.finish(), None);
 
@@ -1771,7 +1763,7 @@ impl NestedLoopJoinStream {
 
         // 1. Maybe update the left bitmap
         if need_produce_result_in_final(self.join_type) && (joined_len > 0) {
-            let mut bitmap = left_data.bitmap().lock();
+            let bitmap = left_data.bitmap();
             bitmap.set_bit(l_index, true);
         }
 

--- a/datafusion/physical-plan/src/joins/piecewise_merge_join/classic_join.rs
+++ b/datafusion/physical-plan/src/joins/piecewise_merge_join/classic_join.rs
@@ -599,7 +599,7 @@ fn build_matched_indices_and_set_buffered_bitmap(
 ) -> Result<RecordBatch> {
     // Mark the buffered indices as visited
     if need_produce_result_in_final(join_type) {
-        let mut bitmap = buffered_side.buffered_data.visited_indices_bitmap.lock();
+        let bitmap = &buffered_side.buffered_data.visited_indices_bitmap;
         for i in buffered_range.0..buffered_range.0 + buffered_range.1 {
             bitmap.set_bit(i, true);
         }

--- a/datafusion/physical-plan/src/joins/piecewise_merge_join/exec.rs
+++ b/datafusion/physical-plan/src/joins/piecewise_merge_join/exec.rs
@@ -17,7 +17,7 @@
 
 use arrow::array::Array;
 use arrow::{
-    array::{ArrayRef, BooleanBufferBuilder, RecordBatch},
+    array::{ArrayRef, RecordBatch},
     compute::concat_batches,
     util::bit_util,
 };
@@ -36,7 +36,6 @@ use datafusion_physical_expr::{
 };
 use datafusion_physical_expr_common::physical_expr::fmt_sql;
 use futures::TryStreamExt;
-use parking_lot::Mutex;
 use std::fmt::Formatter;
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
@@ -46,6 +45,7 @@ use crate::execution_plan::{EmissionType, boundedness_from_children};
 use crate::joins::piecewise_merge_join::classic_join::{
     ClassicPWMJStream, PiecewiseMergeJoinStreamState,
 };
+use crate::joins::atomic_bit_set::AtomicBitSet;
 use crate::joins::piecewise_merge_join::utils::{
     build_visited_indices_map, is_existence_join, is_right_existence_join,
 };
@@ -620,7 +620,7 @@ async fn build_buffered_data(
 
     // Combine batches and record number of rows
     let initial = (Vec::new(), 0, metrics, reservation);
-    let (batches, num_rows, metrics, mut reservation) = buffered
+    let (batches, _num_rows, metrics, mut reservation) = buffered
         .try_fold(initial, |mut acc, batch| async {
             let batch_size = get_record_batch_memory_size(&batch);
             acc.3.try_grow(batch_size)?;
@@ -655,17 +655,15 @@ async fn build_buffered_data(
         reservation.try_grow(bitmap_size)?;
         metrics.build_mem_used.add(bitmap_size);
 
-        let mut bitmap_buffer = BooleanBufferBuilder::new(single_batch.num_rows());
-        bitmap_buffer.append_n(num_rows, false);
-        bitmap_buffer
+        AtomicBitSet::new(single_batch.num_rows())
     } else {
-        BooleanBufferBuilder::new(0)
+        AtomicBitSet::new(0)
     };
 
     let buffered_data = BufferedSideData::new(
         single_batch,
         buffered_values,
-        Mutex::new(visited_indices_bitmap),
+        Arc::new(visited_indices_bitmap),
         remaining_partitions,
         reservation,
     );

--- a/datafusion/physical-plan/src/joins/utils.rs
+++ b/datafusion/physical-plan/src/joins/utils.rs
@@ -26,6 +26,7 @@ use std::ops::Range;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
+use crate::joins::atomic_bit_set::AtomicBitSet;
 use crate::joins::SharedBitmapBuilder;
 use crate::metrics::{
     self, BaselineMetrics, ExecutionPlanMetricsSet, MetricBuilder, MetricType,
@@ -860,8 +861,7 @@ pub(crate) fn get_final_indices_from_shared_bitmap(
     join_type: JoinType,
     piecewise: bool,
 ) -> (UInt64Array, UInt32Array) {
-    let bitmap = shared_bitmap.lock();
-    get_final_indices_from_bit_map(&bitmap, join_type, piecewise)
+    get_final_indices_from_bit_map(shared_bitmap, join_type, piecewise)
 }
 
 /// In the end of join execution, need to use bit map of the matched
@@ -874,7 +874,7 @@ pub(crate) fn get_final_indices_from_shared_bitmap(
 ///
 /// The result is: `([1,4], [null, null])`
 pub(crate) fn get_final_indices_from_bit_map(
-    left_bit_map: &BooleanBufferBuilder,
+    left_bit_map: &AtomicBitSet,
     join_type: JoinType,
     // We add a flag for whether this is being passed from the `PiecewiseMergeJoin`
     // because the bitmap can be for left + right `JoinType`s


### PR DESCRIPTION
Resolved lock contention in join operations by introducing a thread-safe `AtomicBitSet`.

Summary of changes:
1. Introduced `AtomicBitSet` in `datafusion/physical-plan/src/joins/atomic_bit_set.rs`.
2. Redefined `SharedBitmapBuilder` as `Arc<AtomicBitSet>` in `datafusion/physical-plan/src/joins/mod.rs`.
3. Updated `HashJoinExec`, `NestedLoopJoinExec`, and `PiecewiseMergeJoinExec` to use atomic bit set operations instead of locking a `BooleanBufferBuilder`.
4. Updated utility functions in `datafusion/physical-plan/src/joins/utils.rs` to handle `AtomicBitSet`.
5. Cleaned up unused imports and addressed lint warnings.

---
*PR created automatically by Jules for task [14507652605152518059](https://jules.google.com/task/14507652605152518059) started by @Dandandan*